### PR TITLE
Fix: D3 visual requery rendered properly

### DIFF
--- a/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/Helper.java
+++ b/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/Helper.java
@@ -74,17 +74,19 @@ public class Helper {
 	}
 	
 	public static String generate_library_query(String input) {
-		// Wiki endpoint
-		// String url =
-		// "http://dbpedia.org/sparql?query=SELECT+?subject+?predicate+?object+WHERE+{+?subject+?predicate+?object+}+LIMIT+3&format=json";
-		// Jena Endpoint
-		// String url =
-		// "http://localhost:3030/ds/sparql?query=SELECT+?subject+?predicate+?object+WHERE+{+?subject+?predicate+?object+}+LIMIT+3&format=json";
-
 		// Jena Endpoint for specific search
 		input = "%22"+input.replaceAll(" ", "%20")+"%22";
 		String url = 
 		"http://localhost:3030/ds/sparql?query=select+?subject+?predicate+?object+WHERE+{+?subject+?predicate+?object+.+FILTER+(+REGEX(STR(?subject),+" + input + "+)+%7C%7C+REGEX(STR(?predicate),+"+input+"+)+%7C%7C+REGEX(STR(?object),+"+input+"+)+)+}";
+
+		return url;
+	}
+
+	public static String generate_librarysubject_query(String input) {
+		// jena endpoint for library subject search
+		input = "%22"+input.replaceAll(" ", "%20")+"%22";
+		String url = 
+		"http://localhost:3030/ds/sparql?query=select+?subject+?predicate+?object+WHERE+{+?subject+?predicate+?object+.+FILTER+(+REGEX(STR(?subject),+" + input + "+)+)+}";
 
 		return url;
 	}

--- a/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/Helper.java
+++ b/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/Helper.java
@@ -82,8 +82,11 @@ public class Helper {
 		return url;
 	}
 
+	/* UC Davis Library Catalog */
+	/* NOTE: 
+		- called from librarysubject route only for "/subjects/" nodes from D3
+	 */
 	public static String generate_librarysubject_query(String input) {
-		// jena endpoint for library subject search
 		input = "%22"+input.replaceAll(" ", "%20")+"%22";
 		String url = 
 		"http://localhost:3030/ds/sparql?query=select+?subject+?predicate+?object+WHERE+{+?subject+?predicate+?object+.+FILTER+(+REGEX(STR(?subject),+" + input + "+)+)+}";

--- a/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/LibrarySubject.java
+++ b/TripleDataProcessor/src/main/java/org/ECS193/TripleDataProcessor/routes/LibrarySubject.java
@@ -1,0 +1,39 @@
+package org.ECS193.TripleDataProcessor.routes;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.ECS193.TripleDataProcessor.data.Data;
+import org.ECS193.TripleDataProcessor.data.EndPoint.ENDPOINT_TYPE;
+import org.json.JSONObject;
+
+@Path("librarysubject")
+public class LibrarySubject {
+	
+	@POST   
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	public String post(String input) {
+		System.out.println("POST request: " + input);
+		String result = "";
+		String url = "";
+		JSONObject jsonObject = new JSONObject();
+		try {
+			url = Helper.generate_librarysubject_query(input);
+			result = Helper.query(url);
+			Data data = new Data(result, ENDPOINT_TYPE.library);
+			jsonObject = data.constructJSON(input);
+
+		}
+		catch(Exception e) {
+			e.printStackTrace();
+		}
+	  
+		return jsonObject.toString();
+		
+	}
+
+}

--- a/TripleDataProcessor/src/main/webapp/index.html
+++ b/TripleDataProcessor/src/main/webapp/index.html
@@ -15,7 +15,7 @@
 <body>
 <p>GRAPH</p>
 
-<svg width="960" height="500"></svg>
+<svg width="1300" height="1300"></svg>
 <script src="http://d3js.org/d3.v4.min.js" type="text/javascript"></script>
 <script src="http://d3js.org/d3-selection-multi.v1.js"></script>
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>

--- a/TripleDataProcessor/src/main/webapp/js/graph.js
+++ b/TripleDataProcessor/src/main/webapp/js/graph.js
@@ -58,7 +58,7 @@ function parsePredicateValue(predicateURI) {
 // involves removing duplicate links, nodes and appending to global
 // graph JSON properly
 // basically has the logic for the aggregation
-
+// && URI_filter(key.object.value)
 function createGraph(json) {
     Object.keys(json).forEach(function(key) {
         var triples = json[key];
@@ -100,7 +100,7 @@ function createGraph(json) {
 }
 
 function URI_filter(uri){
-	if(uri.search("/oclc/") !== -1 || uri.search("/names/") !== -1  || uri.search("/bibs/") !== -1)
+	if(uri.search("/oclc/") !== -1 || uri.search("/names/") !== -1  || uri.search("/bibs/") !== -1 || uri.search("/subjects/") !== -1)
 		return true;
 	return false;
 }
@@ -126,17 +126,35 @@ function requery() {
             break;
         }
         console.log(URIs[i]);
-        jQuery.ajax({
+
+        if (URIs[i].search("/subjects/")) {
+            jQuery.ajax({
+            type: "POST",
+            url: "http://localhost:8080/TripleDataProcessor/webapi/librarysubject",
+            data: URIs[i],
+            contentType: "application/json",
+            success: function(json) {
+                console.log("POST successful");
+                createGraph(json);
+                update();
+            }
+            });
+        }
+        else {
+            jQuery.ajax({
             type: "POST",
             url: "http://localhost:8080/TripleDataProcessor/webapi/library",
             data: URIs[i],
             contentType: "application/json",
             success: function(json) {
                 console.log("POST successful");
-				createGraph(json);
-				update();
+                createGraph(json);
+                update();
             }
         });
+
+        }
+
         i++;
     }
 RQreps++;

--- a/TripleDataProcessor/src/main/webapp/js/graph.js
+++ b/TripleDataProcessor/src/main/webapp/js/graph.js
@@ -253,13 +253,19 @@ function update() {
 
 function ticked() {
 
-    link = svg.selectAll(".link")
-        .attr("x1", function(d) { return d.source.x; })
-        .attr("y1", function(d) { return d.source.y; })
-        .attr("x2", function(d) { return d.target.x; })
-        .attr("y2", function(d) { return d.target.y; });
-    node = svg.selectAll(".node")
-        .attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; });
+	let radius = 15;
+
+   link = svg.selectAll(".link")
+		.attr("x1", function (d) {return Math.max(radius, Math.min(width-radius, d.source.x));})
+        .attr("y1", function (d) {return Math.max(radius, Math.min(width-radius, d.source.y));})
+        .attr("x2", function (d) {return Math.max(radius, Math.min(height-radius, d.target.x));})
+        .attr("y2", function (d) {return Math.max(radius, Math.min(height-radius, d.target.y));});
+
+   node = svg.selectAll(".node")
+        .attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; })
+		.attr("cx", function(d) { return d.x = Math.max(radius, Math.min(width - radius, d.x)); })
+        .attr("cy", function(d) { return d.y = Math.max(radius, Math.min(height - radius, d.y)); });
+
     edgepaths.attr('d', function(d) {
         return 'M ' + d.source.x + ' ' + d.source.y + ' L ' + d.target.x + ' ' + d.target.y;
     });

--- a/TripleDataProcessor/src/main/webapp/js/graph.js
+++ b/TripleDataProcessor/src/main/webapp/js/graph.js
@@ -49,12 +49,21 @@ function removeDuplicateNodes(originalArray) {
 // returns new list of links that does not contain duplicates
 function removeDuplicateLinks(origLinkArray) {
 
-    var filtered = origLinkArray.filter(function (a) {
-        return a.source !== this.source && a.target !== this.target
-            && a.predicate !== this.predicate;
+    var map = {};
+    origLinkArray.forEach(function(value, index){
+        var obj = JSON.stringify({
+            source: value.source.id,
+            target: value.target.id,
+            predicate: value.predicate
+        });
+        if (!map[obj]) {
+            map[obj] = true;
+        }
+        else {
+            origLinkArray.splice(index, 1);
+        }
     });
-
-    return filtered;
+    return origLinkArray;
 }
 
 // converting the predicate URI into string

--- a/TripleDataProcessor/src/main/webapp/js/graph.js
+++ b/TripleDataProcessor/src/main/webapp/js/graph.js
@@ -26,8 +26,8 @@ var simulation = d3.forceSimulation()
     .force("center", d3.forceCenter(width / 2, height / 2))
     .force("x", d3.forceX())
     .force("y", d3.forceY())
-    .alphaTarget(0.3)
-    .on("tick", ticked);
+    .alphaTarget(0.3);
+    // .on("tick", ticked);
 
 // initializing all global variables
 // we are no longer popping off of this array, instead we are
@@ -129,8 +129,8 @@ function createGraph(json) {
                 }
 
                 // if((nodes.findIndex(x => x.id == key.subject.value) || nodes.findIndex(x => x.id == key.object.value)) == 13 )
-                console.log("hi\n",UniversalN.findIndex(x => x.id == key.subject.value), key.subject.value);
-                console.log(UniversalN.findIndex(x => x.id == key.object.value), key.object.value)
+                // console.log("hi\n",UniversalN.findIndex(x => x.id == key.subject.value), key.subject.value);
+                // console.log(UniversalN.findIndex(x => x.id == key.object.value), key.object.value)
                 // console.log(node.id);
                 triple["source"] = UniversalN.findIndex(function(x){ return x.id === key.subject.value});
                 triple["target"] = UniversalN.findIndex(function(x){ return x.id === key.object.value});
@@ -152,7 +152,7 @@ function createGraph(json) {
     // }
     
 
-    console.log("GraphNodes", UniversalN);
+    // console.log("GraphNodes", UniversalN);
 
     graph["nodes"] = nodes;
     graph["links"] = links;
@@ -299,23 +299,60 @@ function update(links, nodes) {
         })
         .merge(edgelabels);
 
-    node = svg.selectAll(".node")
-        .data(nodes, function(d) {return d.id;});
+        var g = svg.append("g")
+            .attr("class", "everything");
 
-    node.exit().remove();
+    var nodesd = g.append("g")
+        .attr("class", "nodes");
 
-    node = node.enter()
-        .append("circle")
+var node = nodesd.selectAll("g")
+        .data(nodes)
+        .enter()
+        .append("g")
+            .attr('class', 'node');
+
+var circle = node.append("circle")
         .attr("r", 15)
-        .style("fill", function(d) { return colors(d.group); })
-        .merge(node);
+        .attr("fill", function(d) { return colors(d.group); })
+        .attr("cx", 0)
+        .attr("cy", 0);
 
-    node = node.attr("class", "node")
-        .call(d3.drag()
-            .on("start", dragstarted)
-            .on("drag", dragged)
-            // .on("end", dragended)
-        );
+var text = node.append("text")
+        .style("text-anchor", "middle");
+
+// Add drag capabilities
+var drag_handler = d3.drag()
+    .on("start", dragstarted)
+    .on("drag", dragged);
+    // .on("end", drag_end);
+
+drag_handler(node);
+
+    // node = svg.selectAll("g")
+    //     .data(nodes)
+    //     .text(function(d) {return d.id;});
+
+    // node.exit().remove();
+
+    // node = node.enter()
+    //     .append("circle")
+    //     .attr("r", 15)
+    //     .style("fill", function(d) { return colors(d.group); })
+    //     .merge(node);
+
+    // node = node.enter()
+    //     .append("g")
+    //     .attr("r", 15)
+    //     .style("fill", function(d) { return colors(d.group); })
+    //     .merge(node);
+
+
+    // node = node.attr("class", "node")
+    //     .call(d3.drag()
+    //         .on("start", dragstarted)
+    //         .on("drag", dragged)
+    //         // .on("end", dragended)
+    //     );
 
 
 
@@ -343,7 +380,7 @@ function update(links, nodes) {
         .style("font-size", "0.7em")
         .text(function(d) { return d.id; });
 
-    simulation.nodes(nodes);
+    simulation.nodes(nodes).on("tick", ticked);
     simulation.force("link").links(links);
     // simulation.restart();
 


### PR DESCRIPTION
The requery now does not result in duplicate nodes or links.
The graph also updates with the proper links pointing to the nodes.
Fix involved replacing source and target strings with nodes array index.
Also on a query, we only push new and unique codes into the arrays. The 
d3 API takes care of the rest.